### PR TITLE
feat: criar formulário de pedido de férias e adicionar um botao de guardar formulário

### DIFF
--- a/trabalho_gp/src/App.jsx
+++ b/trabalho_gp/src/App.jsx
@@ -5,6 +5,8 @@ import RegisterPage from "./pages/RegisterPage";
 import DashboardPage from "./pages/DashboardPage";
 import PrivateRoute from "./components/PrivateRoute";
 import Create_form from "./components/Create_form";
+import MyFormsPage from "./pages/MyFormsPage";
+
 
 function App() {
   return (
@@ -30,6 +32,15 @@ function App() {
           </PrivateRoute>
         }
       />
+
+      <Route
+  path="/meus-formularios"
+  element={
+    <PrivateRoute>
+      <MyFormsPage />
+    </PrivateRoute>
+  }
+/>
     </Routes>
   );
 }

--- a/trabalho_gp/src/components/Create_form.jsx
+++ b/trabalho_gp/src/components/Create_form.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { DndContext } from "@dnd-kit/core";
 
 import FormCanvas from "./FormCanvas";
@@ -7,9 +8,12 @@ import FieldEditor from "./FieldEditor";
 import "./create_forms.css";
 
 export default function Create_form() {
+  const navigate = useNavigate();
+
   const [fields, setFields] = useState([]);
   const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
   const [selectedFieldId, setSelectedFieldId] = useState(null);
+  const [formTitle, setFormTitle] = useState("");
 
   const selectedField = fields.find((f) => f.id === selectedFieldId);
 
@@ -44,7 +48,6 @@ export default function Create_form() {
     const x = finalX - rect.left;
     const y = finalY - rect.top;
 
-    // NOVO
     if (active.data.current?.from === "palette") {
       setFields((prev) => [
         ...prev,
@@ -62,7 +65,6 @@ export default function Create_form() {
       return;
     }
 
-    // MOVER
     if (active.data.current?.from === "canvas") {
       setFields((prev) =>
         prev.map((field) =>
@@ -84,20 +86,73 @@ export default function Create_form() {
     );
   }
 
+  function handleSaveForm() {
+    const trimmedTitle = formTitle.trim();
+
+    if (!trimmedTitle) {
+      alert("Escreve um título para o formulário.");
+      return;
+    }
+
+    if (fields.length === 0) {
+      alert("Adiciona pelo menos um campo antes de guardar.");
+      return;
+    }
+
+    const newForm = {
+      id: crypto.randomUUID(),
+      title: trimmedTitle,
+      createdAt: new Date().toISOString(),
+      fields: fields,
+    };
+
+    const existingForms = JSON.parse(localStorage.getItem("myForms")) || [];
+
+    localStorage.setItem(
+      "myForms",
+      JSON.stringify([...existingForms, newForm])
+    );
+
+    alert("Formulário guardado com sucesso!");
+    navigate("/meus-formularios");
+  }
+
   return (
     <DndContext onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
-      <div className="builder">
-        <FormCanvas
-          fields={fields}
-          setSelectedField={setSelectedFieldId}
-        />
+      <div className="create-form-page">
+        <div className="form-header">
+          <input
+            type="text"
+            value={formTitle}
+            onChange={(e) => setFormTitle(e.target.value)}
+            className="form-title-input"
+            placeholder="Escreve o título do formulário"
+          />
 
-        <FieldPalette />
+          <div className="header-buttons">
+            <button className="back-btn" onClick={() => navigate(-1)}>
+              Voltar
+            </button>
 
-        <FieldEditor
-          field={selectedField}
-          updateField={updateField}
-        />
+            <button className="save-btn" onClick={handleSaveForm}>
+              Guardar formulário
+            </button>
+          </div>
+        </div>
+
+        <div className="builder">
+          <FormCanvas
+            fields={fields}
+            setSelectedField={setSelectedFieldId}
+          />
+
+          <FieldPalette />
+
+          <FieldEditor
+            field={selectedField}
+            updateField={updateField}
+          />
+        </div>
       </div>
     </DndContext>
   );

--- a/trabalho_gp/src/components/create_forms.css
+++ b/trabalho_gp/src/components/create_forms.css
@@ -2,7 +2,7 @@
 .builder {
   padding-right: 10px;
   display: flex;
-  height: 100vh;
+  flex: 1;
   background-color: #f5f6f8;
   font-family: "Segoe UI", sans-serif;
 }
@@ -47,10 +47,8 @@
   inset: 0;
   padding: 20px;
   z-index: 1;
-
   font-size: 16px;
   color: #222;
-
   outline: none;
   cursor: text;
 }
@@ -60,17 +58,13 @@
   position: absolute;
   inset: 0;
   z-index: 2;
-
   border: 2px dashed #ccc;
   border-radius: 10px;
-
   background: transparent;
-
   pointer-events: none;
   transition: all 0.2s ease;
 }
 
-/* 🔹 Hover canvas */
 .canvas.over {
   border-color: #4a90e2;
   background-color: rgba(74, 144, 226, 0.05);
@@ -80,26 +74,20 @@
 .canvas-field {
   pointer-events: all;
   position: absolute;
-
-  
   padding: 8px;
   border-radius: 8px;
-
   transition: all 0.15s ease;
 }
 
-/* 🔹 Hover campo */
 .canvas-field:hover {
   box-shadow: 0 4px 10px rgba(0,0,0,0.08);
 }
 
-/* 🔹 Campo selecionado */
 .canvas-field.selected {
   border: 2px solid #4a90e2;
   box-shadow: 0 0 0 2px rgba(74,144,226,0.2);
 }
 
-/* 🔹 Dragging */
 .canvas-field:active {
   opacity: 0.85;
   cursor: grabbing;
@@ -107,20 +95,17 @@
   border-color: #4a90e2;
 }
 
-/* 🔹 Inputs dentro dos campos */
+/* 🔹 Inputs */
 .canvas-field input,
 .canvas-field textarea,
 .canvas-field select {
   width: 100%;
   padding: 6px;
   margin-top: 5px;
-
   border-radius: 5px;
   border: 1px solid #ccc;
-
   background-color: #fff;
   color: #333;
-
   transition: border 0.15s ease;
 }
 
@@ -161,7 +146,6 @@
   width: 100%;
   padding: 8px;
   margin-bottom: 10px;
-
   border-radius: 6px;
   border: 1px solid #ccc;
 }
@@ -178,4 +162,70 @@
 
 .editor button:hover {
   background: #357abd;
+}
+
+/* PÁGINA COMPLETA */
+.create-form-page {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+/* HEADER */
+.form-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 24px;
+  background: #ffffff;
+  border-bottom: 1px solid #ddd;
+}
+
+/* INPUT TÍTULO */
+.form-title-input {
+  font-size: 1.8rem;
+  font-weight: 400;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: #222;
+  min-width: 300px;
+}
+
+/* BOTÕES */
+.header-buttons {
+  display: flex;
+  gap: 10px;
+}
+
+/* BOTÃO GUARDAR */
+.save-btn {
+  background: #4a90e2;
+  color: white;
+  border: none;
+  padding: 10px 16px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 500;
+  transition: 0.2s;
+}
+
+.save-btn:hover {
+  background: #357abd;
+}
+
+/* BOTÃO VOLTAR */
+.back-btn {
+  background: #e5e7eb;
+  color: #111827;
+  border: none;
+  padding: 10px 16px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 500;
+  transition: 0.2s;
+}
+
+.back-btn:hover {
+  background: #d1d5db;
 }

--- a/trabalho_gp/src/pages/DashboardPage.jsx
+++ b/trabalho_gp/src/pages/DashboardPage.jsx
@@ -12,9 +12,9 @@ function handleCreateForm() {
   navigate("/criar-formulario");
 }
 
-  function handleMyForms() {
-    alert("Página de formulários em desenvolvimento.");
-  }
+function handleMyForms() {
+  navigate("/meus-formularios");
+}
 
   function handleResponses() {
     alert("Página de respostas em desenvolvimento.");

--- a/trabalho_gp/src/pages/MyFormsPage.css
+++ b/trabalho_gp/src/pages/MyFormsPage.css
@@ -1,0 +1,143 @@
+.myforms-page {
+  min-height: 100vh;
+  background: #f5f6f8;
+  padding: 48px 24px;
+  font-family: "Segoe UI", sans-serif;
+}
+
+.myforms-container {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.myforms-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 32px;
+  gap: 20px;
+}
+
+.myforms-title {
+  font-size: 3rem;
+  font-weight: 700;
+  color: #0f172a;
+  margin: 0;
+}
+
+.myforms-top-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.myforms-list {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.form-card {
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 18px;
+  padding: 24px 28px;
+  box-shadow: 0 8px 22px rgba(15, 23, 42, 0.06);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 20px;
+}
+
+.form-card-title {
+  margin: 0 0 10px 0;
+  font-size: 1.6rem;
+  color: #0f172a;
+}
+
+.form-card-info {
+  color: #475569;
+  line-height: 1.7;
+}
+
+.form-card-info p {
+  margin: 0;
+}
+
+.form-card-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.myforms-empty-box {
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 18px;
+  padding: 40px;
+  text-align: center;
+  box-shadow: 0 8px 22px rgba(15, 23, 42, 0.06);
+}
+
+.myforms-empty {
+  color: #64748b;
+  font-size: 1.1rem;
+  margin-bottom: 20px;
+}
+
+.new-form-btn,
+.back-btn,
+.view-btn,
+.edit-btn,
+.delete-btn {
+  border: none;
+  border-radius: 10px;
+  padding: 10px 16px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: 0.2s;
+}
+
+.new-form-btn {
+  background: #4a90e2;
+  color: white;
+}
+
+.new-form-btn:hover {
+  background: #357abd;
+}
+
+.back-btn {
+  background: #e5e7eb;
+  color: #111827;
+}
+
+.back-btn:hover {
+  background: #d1d5db;
+}
+
+.view-btn {
+  background: #e0f2fe;
+  color: #0369a1;
+}
+
+.view-btn:hover {
+  background: #bae6fd;
+}
+
+.edit-btn {
+  background: #ede9fe;
+  color: #6d28d9;
+}
+
+.edit-btn:hover {
+  background: #ddd6fe;
+}
+
+.delete-btn {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.delete-btn:hover {
+  background: #fecaca;
+}

--- a/trabalho_gp/src/pages/MyFormsPage.jsx
+++ b/trabalho_gp/src/pages/MyFormsPage.jsx
@@ -1,0 +1,111 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import "./MyFormsPage.css";
+
+export default function MyFormsPage() {
+  const [forms, setForms] = useState([]);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const savedForms = JSON.parse(localStorage.getItem("myForms")) || [];
+    setForms(savedForms);
+  }, []);
+
+  function handleDeleteForm(formId) {
+    const confirmDelete = window.confirm(
+      "Tens a certeza que queres eliminar este formulário?"
+    );
+
+    if (!confirmDelete) return;
+
+    const updatedForms = forms.filter((form) => form.id !== formId);
+    setForms(updatedForms);
+    localStorage.setItem("myForms", JSON.stringify(updatedForms));
+  }
+
+  function handleEditForm(formId) {
+    navigate(`/criar-formulario/${formId}`);
+  }
+
+  function handleViewForm(formId) {
+    navigate(`/formulario/${formId}`);
+  }
+
+  return (
+    <div className="myforms-page">
+      <div className="myforms-container">
+        <div className="myforms-header">
+          <h1 className="myforms-title">Os meus formulários</h1>
+
+          <div className="myforms-top-actions">
+            <button className="back-btn" onClick={() => navigate("/dashboard")}>
+              Voltar
+            </button>
+
+            <button
+              className="new-form-btn"
+              onClick={() => navigate("/criar-formulario")}
+            >
+              Criar novo formulário
+            </button>
+          </div>
+        </div>
+
+        {forms.length === 0 ? (
+          <div className="myforms-empty-box">
+            <p className="myforms-empty">
+              Ainda não tens formulários guardados.
+            </p>
+            <button
+              className="new-form-btn"
+              onClick={() => navigate("/criar-formulario")}
+            >
+              Criar primeiro formulário
+            </button>
+          </div>
+        ) : (
+          <div className="myforms-list">
+            {forms.map((form) => (
+              <div key={form.id} className="form-card">
+                <div className="form-card-content">
+                  <h2 className="form-card-title">{form.title}</h2>
+
+                  <div className="form-card-info">
+                    <p>Número de campos: {form.fields.length}</p>
+                    <p>
+                      Criado em:{" "}
+                      {new Date(form.createdAt).toLocaleDateString("pt-PT")}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="form-card-actions">
+                  <button
+                    className="view-btn"
+                    onClick={() => handleViewForm(form.id)}
+                  >
+                    Ver
+                  </button>
+
+                  <button
+                    className="edit-btn"
+                    onClick={() => handleEditForm(form.id)}
+                  >
+                    Editar
+                  </button>
+
+                  <button
+                    className="delete-btn"
+                    onClick={() => handleDeleteForm(form.id)}
+                  >
+                    Eliminar
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- Criação de formulário dinâmico, permitindo adicionar diferentes tipos de campos
- Adição de campo editável para o título do formulário
- Implementação do botão “Guardar formulário”
- Armazenamento dos formulários no localStorage
- Estrutura de dados para guardar:
- id do formulário
- título
- data de criação
- lista de campos
- Redirecionamento automático para a página “Os meus formulários” após guardar
- Criação da página “Os meus formulários” para listar formulários guardados
- Apresentação de informações de cada formulário:
- título
- número de campos
- data de criação
- Ligação do botão “Criar formulário” ao construtor
- Ligação do botão “Os meus formulários” à listagem
- Adição de botão “Voltar” no construtor de formulários