### PR TITLE
Add password change UI and fix session handling

### DIFF
--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -108,7 +108,7 @@ export default function DashboardPage() {
         </nav>
 
         <div className="sidebar-logout">
-          <button className="sidebar-item" onClick={() => navigate("/login")}>
+          <button className="sidebar-item" onClick={() => {removeToken(); navigate("/login"); }}>
             <svg className="sidebar-item-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
               <polyline points="16 17 21 12 16 7" />

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -65,7 +65,7 @@ export default function LoginPage() {
         throw new Error(data.error || "Erro ao autenticar.");
       }
 
-      saveToken(data.user);
+      saveToken(data);
       setSuccess("Login efetuado com sucesso.");
       const role = getUserRole();
       setTimeout(() => navigate(role === "USER" ? "/inicio" : "/dashboard"), 1000);

--- a/src/pages/UserPage.jsx
+++ b/src/pages/UserPage.jsx
@@ -1,20 +1,101 @@
 import "../css/UserPage.css";
 import { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
-import {getUser} from "../utils/session";
+import { useParams, useNavigate } from "react-router-dom";
+import {getUser, removeToken} from "../utils/session";
 
 export default function UserPage() {
   const { id } = useParams();
-  const [user, setUser] = useState(getUser());
+  const navigate = useNavigate();
+  const [user, setUser] = useState(getUser().user);
+  const [passwords, setPasswords] = useState({
+    current: "",
+    new: "",
+    confirm: "",
+  });
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
 
+  async function resetPass(e) {
+    e.preventDefault();
+    setError("");
+    setSuccess("");
 
+    if (!passwords.current || !passwords.new || !passwords.confirm) {
+      setError("Preencha todos os campos.");
+      return;
+    }
+    if (passwords.new !== passwords.confirm) {
+      setError("A nova palavra-passe e a confirmação não coincidem.");
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/auth/change-password`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${getUser()?.token}`
+        },
+        body: JSON.stringify({
+          currentPassword: passwords.current,
+          newPassword: passwords.new
+        }),
+      });
+      if (!response.ok) {
+        throw new Error("Failed to change password");
+      }
+      setSuccess("Password changed successfully");
+      setPasswords({
+        current: "",
+        new: "",
+        confirm: "",
+      });
+
+      setTimeout(() => {
+        setSuccess("");
+        removeToken();
+        navigate("/login");
+        //clear cookies
+      }, 3000);
+    } catch (error) {
+      setError(error.message);
+    }
+  }
 
   return (
     <div id="userpage">
-        <h1>User Profile</h1>
-        <p><strong>Name:</strong> {user?.name || "N/A"}</p>
-        <p><strong>Email:</strong> {user?.email || "N/A"}</p>
-        <p><strong>Role:</strong> {user?.role || "N/A"}</p>
+      <div id="user-info">
+          <h1>User Profile</h1>
+          <p><strong>Name:</strong> {user?.name || "N/A"}</p>
+          <p><strong>Email:</strong> {user?.email || "N/A"}</p>
+          <p><strong>Role:</strong> {user?.role || "N/A"}</p>
+      </div>
+      <div>
+        <p> change password </p>
+        <form onSubmit={resetPass}>
+          <input
+            type="password"
+            placeholder="Current Password"
+            value={passwords.current}
+            onChange={(e) => setPasswords({...passwords, current: e.target.value})}
+          />
+          <input
+            type="password"
+            placeholder="New Password"
+            value={passwords.new}
+            onChange={(e) => setPasswords({...passwords, new: e.target.value})}
+          />
+          <input
+            type="password"
+            placeholder="Confirm New Password"
+            value={passwords.confirm}
+            onChange={(e) => setPasswords({...passwords, confirm: e.target.value})}
+          />
+          <button type="submit">Change Password</button>
+        </form>
+        {error && <p className="error">{error}</p>}
+        {success && <p className="success">{success}</p>}
+      </div>
     </div>
   );
 

--- a/src/utils/session.js
+++ b/src/utils/session.js
@@ -28,5 +28,5 @@ export function getUser() {
 }
 
 export function getUserRole() {
-  return getUser()?.role || null;
+  return getUser()?.user?.role || null;
 }


### PR DESCRIPTION
Add a password-change form and handler on UserPage, including API call to /api/auth/change-password, success/error messages, and auto-logout (removeToken + navigate to /login) after password change. Adjust UserPage to read user from getUser().user and import removeToken/useNavigate. Fix Dashboard logout to remove token before navigating. Update LoginPage to save the full auth response (saveToken(data)) so token is preserved, and update session.getUserRole() to read role from getUser()?.user?.role to match the new response shape.