### PR TITLE
Update dev server API proxy target

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
   server: {
     proxy: {
       "/api": {
-        target: " https://two026-team-c-backend.onrender.com",
+        target: "https://api.avodore.uk/",
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
Change Vite dev server proxy target in vite.config.js from "https://two026-team-c-backend.onrender.com" (note: original had a leading space) to "https://api.avodore.uk/", ensuring /api requests are routed to the new backend during development.