### PR TITLE
Refactor form layout, styles, and segmented input

### DIFF
--- a/src/components/FormField.jsx
+++ b/src/components/FormField.jsx
@@ -102,7 +102,7 @@ export function FormField({ field }) {
       );
     case "checkbox":
       return (
-        <div className="viewform-field">
+        <div className="viewform-field viewform-checkbox-group">
           <label>{field.label}</label>
           <div className="viewform-checkbox-group" style={{ flexDirection: field.inline ? "row" : "column" }}>
             {(field.options || []).map((opt, i) => (

--- a/src/components/FormRenderer.jsx
+++ b/src/components/FormRenderer.jsx
@@ -9,10 +9,10 @@ export default function FormRenderer({ rows = [], fields = [] }) {
           style={{
             display: "grid",
             gridTemplateColumns: row.colWidths
-              ? row.colWidths.map((w) => `${w}%`).join(" ")
+              ? row.colWidths.map((w) => `${w}fr`).join(" ")
               : `repeat(${row.colCount}, 1fr)`,
             gap: "16px",
-            marginBottom: "16px",
+            marginBottom: "1px",
             alignItems: "start",
           }}
         >

--- a/src/components/FormRow.jsx
+++ b/src/components/FormRow.jsx
@@ -203,7 +203,7 @@ function setRefs(node) {
   setDropRef(node); // droppable
 }
 
-  const gridTemplate = row.colWidths.map((w) => `${w}%`).join(" ");
+  const gridTemplate = row.colWidths.map((w) => `${w}fr`).join(" ");
 
   const {
   attributes,

--- a/src/css/FillFormPage.css
+++ b/src/css/FillFormPage.css
@@ -112,7 +112,6 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  margin-bottom: 12px;
 }
 
 .fill-field > label:first-child {
@@ -129,6 +128,8 @@
   margin-left: 3px;
 }
 
+
+
 .fill-field input[type="text"],
 .fill-field input[type="number"],
 .fill-field input[type="email"],
@@ -137,15 +138,20 @@
 .fill-field select {
   flex: 1;
   padding: 9px 12px;
-  border: 1.5px solid #d1d5db;
-  border-radius: 8px;
+  margin: auto 1px;
+  border-width: 0px 0px 1px 0px;
+  border-color: #000001;
   font-size: 14px;
   color: #111827;
-  background: #fff;
+  background-color: #dde4ff;
   outline: none;
   transition: border-color 0.15s, box-shadow 0.15s;
   font-family: inherit;
   box-sizing: border-box;
+}
+
+.fill-checkbox-group{
+  justify-content: center;
 }
 
 .fill-field input:focus,
@@ -153,6 +159,16 @@
 .fill-field select:focus {
   border-color: #3b82f6;
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.12);
+}
+
+.viewform-field-info{
+  justify-content: center;
+}
+
+
+.fill-field .segmented-square{
+  margin: 1px;
+  border-width: 1px;
 }
 
 .fill-field:has(textarea) {
@@ -169,12 +185,9 @@
   flex: 1;
   min-height: 220px;
   resize: vertical;
-
   padding: 0 12px;
   line-height: 30px;
-
   border: none;
-  border-radius: 0;
   outline: none;
   box-shadow: none;
 
@@ -208,7 +221,6 @@
   color: #374151;
   cursor: pointer;
   padding: 6px 10px;
-  border-radius: 6px;
   transition: background 0.12s;
 }
 
@@ -223,6 +235,8 @@
   height: 15px;
   cursor: pointer;
   flex-shrink: 0;
+  width: 20px;
+  height: 20px;
 }
 
 .fill-other-input {

--- a/src/css/FormSection.css
+++ b/src/css/FormSection.css
@@ -2,7 +2,7 @@
   width: 100%;
   display: flex;
   align-items: center;
-  margin: 18px 0 10px;
+  
 }
 
 .form-section-number {

--- a/src/css/ViewFormPage.css
+++ b/src/css/ViewFormPage.css
@@ -138,7 +138,6 @@
 
 .viewform-container {
   width: 100%;
-  max-width: 640px;
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -172,7 +171,7 @@
   background: #ffffff;
   border: 1px solid #e5e7eb;
   border-radius: 14px;
-  padding: 28px;
+  padding: 1%;
   display: flex;
   flex-direction: column;
   gap: 20px;
@@ -191,21 +190,22 @@
   font-size: 13px;
   font-weight: 600;
   color: #374151;
-  min-width: 90px;   
+  min-width: 0px;   
   max-width: 140px;
 }
 
 .viewform-field input,
 .viewform-field textarea,
 .viewform-field select {
-  flex:1;
-  
+  flex: 1;
+  min-width: 0;
   padding: 10px 14px;
-  border-radius: 10px;
-  border: 1.5px solid #e5e7eb;
+  margin: auto 1px;
+  border-width: 0px 0px 1px 0px ;
+  border-color: #000001;
   font-size: 14px;
   color: #111827;
-  background-color: #f9fafb;
+  background-color: #dde4ff;
   outline: none;
   font-family: inherit;
   transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
@@ -226,12 +226,14 @@
 
 .viewform-field input[type="checkbox"],
 .viewform-field input[type="radio"] {
-  width: auto;
+  width: 20px;
+  height: 20px;
   padding: 0;
   border: none;
   background: transparent;
   box-shadow: none;
   accent-color: #DD6418;
+  justify-content: center;
 }
 
 .viewform-radio-group,
@@ -239,6 +241,7 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+  justify-content: center;
 }
 
 .viewform-radio-option,
@@ -504,10 +507,4 @@
   font-size: 15px; /* Tamanho de letra mais pequeno */
   font-weight: 700;
   color: #374151;
-}
-
-/* Insere a numeração composta (ex: "1.1. ") antes do subtítulo */
-.viewform-field-subtitle h3::before {
-  content: counter(main-title) "." counter(sub-title) ". ";
-
 }

--- a/src/css/create_forms.css
+++ b/src/css/create_forms.css
@@ -78,7 +78,7 @@
 .builder {
   display: flex;
   flex: 1;
-  overflow: hidden;
+  overflow: auto;
 }
 
 /* ── Sidebar ── */

--- a/src/pages/FillFormPage.jsx
+++ b/src/pages/FillFormPage.jsx
@@ -1,10 +1,76 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { getUser } from "../utils/session";
 import InstitutionalHeader from "../components/InstitutionalHeader";
 import InstitutionalFooter from "../components/InstitutionalFooter";
 import FormSection from "../components/FormSection";
 import "../css/FillFormPage.css";
+
+// Controlled segmented input — mirrors SegmentedInput.jsx but tied to fill-form value/onChange
+function FillSegmentedInput({ field, value, onChange }) {
+  const segments = field.segments?.length > 0 ? field.segments : [parseInt(field.segmentsRaw, 10) || 1];
+  const separator = field.separator !== undefined ? field.separator : "";
+  const totalLen = segments.reduce((a, b) => a + b, 0);
+
+  const chars = Array.from({ length: totalLen }, (_, i) => (value || "")[i] || "");
+  const refs = useRef([]);
+  refs.current = [];
+
+  function handleChange(i, e) {
+    const char = e.target.value.slice(-1);
+    const next = [...chars];
+    next[i] = char;
+    onChange(field.id, next.join(""));
+    if (char && i < totalLen - 1) refs.current[i + 1]?.focus();
+  }
+
+  function handleKeyDown(i, e) {
+    if (e.key === "Backspace" && !chars[i] && i > 0) refs.current[i - 1]?.focus();
+    if (e.key === "ArrowLeft"  && i > 0)             refs.current[i - 1]?.focus();
+    if (e.key === "ArrowRight" && i < totalLen - 1)  refs.current[i + 1]?.focus();
+  }
+
+  let flat = 0;
+  const groups = segments.map((count) => {
+    const squares = [];
+    for (let i = 0; i < count; i++) {
+      const fi = flat++;
+      squares.push(
+        <input
+          key={fi}
+          style={{borderWidth: "1px"}}
+          ref={(el) => { if (el) refs.current[fi] = el; }}
+          className="segmented-square"
+          type="text"
+          maxLength={1}
+          value={chars[fi]}
+          onChange={(e) => handleChange(fi, e)}
+          onKeyDown={(e) => handleKeyDown(fi, e)}
+          
+        />
+      );
+    }
+    return squares;
+  });
+
+  return (
+    <div className="fill-field">
+      <label>{field.label}{field.required && <span className="fill-required">*</span>}</label>
+      <div className="segmented-wrapper">
+        <div className="segmented-container">
+          {groups.map((grp, gi) => (
+            <span key={gi} style={{ display: "contents" }}>
+              <div className="segmented-group">{grp}</div>
+              {gi < groups.length - 1 && separator && (
+                <span className="segmented-separator">{separator}</span>
+              )}
+            </span>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
 
 function authHeaders() {
   return {
@@ -111,10 +177,27 @@ function FieldInput({ field, value, onChange }) {
         </div>
       );
 
+    case "segmented":
+      return <FillSegmentedInput field={field} value={value} onChange={onChange} />;
+
     case "title":
       return (
         <div className="fill-field fill-title-field">
           <h2>{field.label}</h2>
+        </div>
+      );
+
+    case "subtitle":
+      return (
+        <div className="fill-field viewform-field-subtitle" style={{ paddingTop: 0 }}>
+          <h3>{field.label}</h3>
+        </div>
+      );
+
+    case "info":
+      return (
+        <div className="fill-field viewform-field-info">
+          <p>{field.label}</p>
         </div>
       );
 
@@ -193,33 +276,52 @@ export default function FillFormPage() {
     }));
   }
 
-  function getFieldsBySection(section) {
-    const sectionRowIds = rows
-      .filter((row) =>
-        section === "foundation"
-          ? !row.section || row.section === "foundation"
-          : row.section === section
-      )
-      .map((row) => row.id);
-
-    return fields.filter((field) => sectionRowIds.includes(field.rowId));
-  }
-
   function renderSectionFields(section) {
-    const sectionFields = getFieldsBySection(section);
+    // Get rows belonging to this section, in order
+    const sectionRows = rows.filter((row) =>
+      section === "foundation"
+        ? !row.section || row.section === "foundation"
+        : row.section === section
+    );
 
-    if (sectionFields.length === 0) {
-      return null;
-    }
+    if (sectionRows.length === 0) return null;
 
-    return sectionFields.map((field) => (
-      <FieldInput
-        key={field.id}
-        field={field}
-        value={answers[field.id]}
-        onChange={handleChange}
-      />
-    ));
+    return sectionRows.map((row) => {
+      // Build colWidths into a CSS grid template
+      const colWidths = row.colWidths || Array(row.colCount).fill(100 / row.colCount);
+      const gridTemplate = colWidths.map((w) => `${w}fr`).join(" ");
+
+      // Map colIndex -> field for this row
+      const colMap = {};
+      fields
+        .filter((f) => f.rowId === row.id)
+        .forEach((f) => { colMap[f.colIndex] = f; });
+
+      return (
+        <div
+          key={row.id}
+          style={{
+            display: "grid",
+            gridTemplateColumns: gridTemplate,
+            gap: "16px",
+            alignItems: "start",
+            marginBottom: "1px",
+          }}
+        >
+          {Array.from({ length: row.colCount }, (_, i) => (
+            <div key={i}>
+              {colMap[i] ? (
+                <FieldInput
+                  field={colMap[i]}
+                  value={answers[colMap[i].id]}
+                  onChange={handleChange}
+                />
+              ) : null}
+            </div>
+          ))}
+        </div>
+      );
+    });
   }
 
   async function handleSubmit(isDraft) {


### PR DESCRIPTION
Update form rendering and layout units, add a controlled segmented input, and adjust visual styles for fill/view pages.

- Replace percent-based grid widths with flexible `fr` units in FormRenderer and FormRow for more consistent column sizing and change row gap/margins to tighter spacing.
- Add FillSegmentedInput (controlled segmented input) in FillFormPage and wire it into FieldInput; add subtitle/info field types.
- Overhaul form input visuals (FillFormPage.css and ViewFormPage.css): switch to underline-style borders, adjusted background color, input/checkbox/radio sizing and alignment, and other spacing tweaks.
- Minor UI/UX fixes: remove max-width on view container, change container padding, enable overflow:auto in create_forms.css to avoid clipping, and small CSS class additions for checkbox/groups and segmented squares.

These changes improve responsive grid behavior, unify input appearance, and introduce the segmented input UI for fill forms.